### PR TITLE
Add Skip True

### DIFF
--- a/project/BuildHelpers.scala
+++ b/project/BuildHelpers.scala
@@ -93,6 +93,9 @@ final case class ProtosProject(
                 |  // so it is not yet included here for backwards-compatiblity.
                 |  // java_conversions: true
                 |  preserve_unknown_fields: true
+                |  [scalapb.validate.file] {
+                |     skip: true
+                |  }
                 |};
             """.stripMargin
           )


### PR DESCRIPTION
Naive approach to solving scalapb/ScalaPB#1358

I'm not aware of what the greater implications of this change might be. However if this is an appropriate fix maybe simply adding a line of documentation indicating that a vendor of protobufs would need to set this value if they set their own package objects and do not have the validation plugin in scope.

Feel free to close this PR if it doesn't make any sense.