### PR TITLE
Update dependency versions of commons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ def commonProtos =
     "com.google.api.grpc" % "proto-google-common-protos" % "2.9.6",
     grpc = true,
     protoPackage = "google",
-    buildNumber = 4
+    buildNumber = 0
   )
 lazy val commonProtos09 = commonProtos.scalapb09
 lazy val commonProtos10 = commonProtos.scalapb10
@@ -23,7 +23,7 @@ val cloudPubSub = ProtosProject(
   "com.google.api.grpc" % "proto-google-cloud-pubsub-v1" % "1.102.20",
   grpc = true,
   protoPackage = "google",
-  buildNumber = 4
+  buildNumber = 0
 ).dependsOn(commonProtos)
 lazy val cloudPubSub09 = cloudPubSub.scalapb09
 lazy val cloudPubSub10 = cloudPubSub.scalapb10
@@ -34,7 +34,7 @@ val pgvProto = ProtosProject(
   grpc = false,
   protoPackage = "validate",
   packageName = Some("pgv-proto"),
-  buildNumber = 1
+  buildNumber = 0
 )
 lazy val pgvProto09 = pgvProto.scalapb09
 lazy val pgvProto10 = pgvProto.scalapb10

--- a/build.sbt
+++ b/build.sbt
@@ -10,31 +10,31 @@ publish / skip := true
 
 def commonProtos =
   ProtosProject(
-    "com.google.api.grpc" % "proto-google-common-protos" % "2.5.0",
+    "com.google.api.grpc" % "proto-google-common-protos" % "2.9.6",
     grpc = true,
     protoPackage = "google",
-    buildNumber = 3
+    buildNumber = 4
   )
 lazy val commonProtos09 = commonProtos.scalapb09
 lazy val commonProtos10 = commonProtos.scalapb10
 lazy val commonProtos11 = commonProtos.scalapb11
 
 val cloudPubSub = ProtosProject(
-  "com.google.api.grpc" % "proto-google-cloud-pubsub-v1" % "1.96.2",
+  "com.google.api.grpc" % "proto-google-cloud-pubsub-v1" % "1.102.20",
   grpc = true,
   protoPackage = "google",
-  buildNumber = 3
+  buildNumber = 4
 ).dependsOn(commonProtos)
 lazy val cloudPubSub09 = cloudPubSub.scalapb09
 lazy val cloudPubSub10 = cloudPubSub.scalapb10
 lazy val cloudPubSub11 = cloudPubSub.scalapb11
 
 val pgvProto = ProtosProject(
-  "io.envoyproxy.protoc-gen-validate" % "pgv-java-stub" % "0.6.3",
+  "build.buf.protoc-gen-validate" % "pgv-java-stub" % "0.6.13",
   grpc = false,
   protoPackage = "validate",
   packageName = Some("pgv-proto"),
-  buildNumber = 0
+  buildNumber = 1
 )
 lazy val pgvProto09 = pgvProto.scalapb09
 lazy val pgvProto10 = pgvProto.scalapb10


### PR DESCRIPTION
A number of the dependencies have seen updates, this pull request updates the dependencies to the latest.


https://mvnrepository.com/artifact/com.google.api.grpc/proto-google-common-protos/2.9.6

https://mvnrepository.com/artifact/com.google.api.grpc/proto-google-cloud-pubsub-v1/1.102.20

https://mvnrepository.com/artifact/io.envoyproxy.protoc-gen-validate/pgv-java-stub
is no longer the artifact location instead it is here
https://mvnrepository.com/artifact/build.buf.protoc-gen-validate/pgv-java-stub/0.6.13
